### PR TITLE
patches: add upstream uhttpd changes for fbwifi

### DIFF
--- a/patches/001-0001-uhttpd-make-organization-O-of-the-cert-configurable-.patch
+++ b/patches/001-0001-uhttpd-make-organization-O-of-the-cert-configurable-.patch
@@ -1,0 +1,61 @@
+From 2c6c1501af664490ec9b701b46a201e21c670b96 Mon Sep 17 00:00:00 2001
+From: Martin Schiller <ms@dev.tdt.de>
+Date: Mon, 4 May 2020 16:13:13 +0200
+Subject: [PATCH] uhttpd: make organization (O=) of the cert configurable via
+ uci
+
+Make the organization (O=) of the cert configurable via uci. If not
+configured, use a combination of "OpenWrt" and an unique id like it was
+done before.
+
+Signed-off-by: Martin Schiller <ms@dev.tdt.de>
+---
+ package/network/services/uhttpd/Makefile          | 2 +-
+ package/network/services/uhttpd/files/uhttpd.init | 5 +++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/package/network/services/uhttpd/Makefile b/package/network/services/uhttpd/Makefile
+index 8f58271127..781512bd99 100644
+--- a/package/network/services/uhttpd/Makefile
++++ b/package/network/services/uhttpd/Makefile
+@@ -8,7 +8,7 @@
+ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=uhttpd
+-PKG_RELEASE:=1
++PKG_RELEASE:=2
+ 
+ PKG_SOURCE_PROTO:=git
+ PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git
+diff --git a/package/network/services/uhttpd/files/uhttpd.init b/package/network/services/uhttpd/files/uhttpd.init
+index 869f79bea2..e7709941c2 100755
+--- a/package/network/services/uhttpd/files/uhttpd.init
++++ b/package/network/services/uhttpd/files/uhttpd.init
+@@ -35,13 +35,14 @@ generate_keys() {
+ 	local cfg="$1"
+ 	local key="$2"
+ 	local crt="$3"
+-	local days bits country state location commonname
++	local days bits country state location organization commonname
+ 
+ 	config_get days       "$cfg" days
+ 	config_get bits       "$cfg" bits
+ 	config_get country    "$cfg" country
+ 	config_get state      "$cfg" state
+ 	config_get location   "$cfg" location
++	config_get organization "$cfg" organization
+ 	config_get commonname "$cfg" commonname
+ 	config_get key_type   "$cfg" key_type
+ 	config_get ec_curve   "$cfg" ec_curve
+@@ -56,7 +57,7 @@ generate_keys() {
+ 	[ -n "$GENKEY_CMD" ] && {
+ 		$GENKEY_CMD \
+ 			-days ${days:-730} -newkey ${KEY_OPTS} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \
+-			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${commonname:-OpenWrt}$UNIQUEID"/CN="${commonname:-OpenWrt}"
++			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${organization:-OpenWrt$UNIQUEID}"/CN="${commonname:-OpenWrt}"
+ 		sync
+ 		mv "${UHTTPD_KEY}.new" "${UHTTPD_KEY}"
+ 		mv "${UHTTPD_CERT}.new" "${UHTTPD_CERT}"
+-- 
+2.32.0
+

--- a/patches/001-0002-uhttpd-add-config-option-for-json_script.patch
+++ b/patches/001-0002-uhttpd-add-config-option-for-json_script.patch
@@ -1,0 +1,47 @@
+From 6393ea15815e57802377ebecb17edf8ad20a0736 Mon Sep 17 00:00:00 2001
+From: Stijn Tintel <stijn@linux-ipv6.be>
+Date: Fri, 20 Aug 2021 14:33:51 +0300
+Subject: [PATCH] uhttpd: add config option for json_script
+
+Add a config option for json_script instead of unconditionally including
+all json files in /etc/uhttpd in every uhttpd instance. This makes it
+possible to configure a single instance with an unconditional redirect,
+which currently renders all other uhttpd instances unusable.
+
+Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
+Acked-by: Felix Fietkau <nbd@nbd.name>
+---
+ package/network/services/uhttpd/Makefile          | 2 +-
+ package/network/services/uhttpd/files/uhttpd.init | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/package/network/services/uhttpd/Makefile b/package/network/services/uhttpd/Makefile
+index 781512bd99..dce5aa87b8 100644
+--- a/package/network/services/uhttpd/Makefile
++++ b/package/network/services/uhttpd/Makefile
+@@ -8,7 +8,7 @@
+ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=uhttpd
+-PKG_RELEASE:=2
++PKG_RELEASE:=3
+ 
+ PKG_SOURCE_PROTO:=git
+ PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git
+diff --git a/package/network/services/uhttpd/files/uhttpd.init b/package/network/services/uhttpd/files/uhttpd.init
+index e7709941c2..30fd7b4259 100755
+--- a/package/network/services/uhttpd/files/uhttpd.init
++++ b/package/network/services/uhttpd/files/uhttpd.init
+@@ -196,7 +196,8 @@ start_instance()
+ 		append_bool "$cfg" redirect_https "-q" 0
+ 	}
+ 
+-	for file in /etc/uhttpd/*.json; do
++	config_get json_script "$cfg" json_script
++	for file in $json_script; do
+ 		[ -s "$file" ] && procd_append_param command -H "$file"
+ 	done
+ 
+-- 
+2.32.0
+


### PR DESCRIPTION
The first patch is not needed, but without it, the second patch would
have to be manually changed or it wouldn't apply